### PR TITLE
this quick fix addresses the **.009999999999 ETH issue attached to transaction (in adding liquidity)

### DIFF
--- a/src/app/service/cofix.service.ts
+++ b/src/app/service/cofix.service.ts
@@ -944,7 +944,7 @@ export class CofiXService {
           this.currentAccount,
           deadline(),
           {
-            value: this.parseEthers(amountETH + fee),
+            value: ethers.utils.parseUnits(Number(amountETH + fee).toString(), 18),
           },
         ]
       );
@@ -960,7 +960,7 @@ export class CofiXService {
           this.currentAccount,
           deadline(),
           {
-            value: this.parseEthers(amountETH + fee),
+            value: ethers.utils.parseUnits(Number(amountETH + fee).toString(), 18),
           },
         ]
       );


### PR DESCRIPTION
 this quick fix addresses the issue that if one adds 1721ETH and 1USDT to the liquidity pool the resulting transaction has 1721.009999999999 ETH attached instead of 1721.01

It doesn't solve a similar issue that happens when someone wishes to swap currency!